### PR TITLE
`terraform-version` Input

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,6 +28,7 @@ jobs:
           terraform-state-role: ${{ secrets.TERRAFORM_STATE_ROLE }}
           terraform-state-bucket: ${{ secrets.TERRAFORM_STATE_BUCKET }}
           terraform-state-table: ${{ secrets.TERRAFORM_STATE_TABLE }}
+          terraform-version: "1.5.2"
           aws-region: ${{ env.AWS_REGION }}
 
   test:
@@ -48,4 +49,5 @@ jobs:
           terraform-state-role: ${{ secrets.TERRAFORM_STATE_ROLE }}
           terraform-state-bucket: ${{ secrets.TERRAFORM_STATE_BUCKET }}
           terraform-state-table: ${{ secrets.TERRAFORM_STATE_TABLE }}
+          terraform-version: "1.5.2"
           aws-region: ${{ env.AWS_REGION }}

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
 
     - uses: hashicorp/setup-terraform@v2
       with:
-        terraform-version: ${{ inputs.terraform-version }}
+        terraform_version: ${{ inputs.terraform-version }}
 
     - uses: actions/setup-node@v3
       with:


### PR DESCRIPTION
## what
- Corrected input arg for Terraform version

## why
- should be `terraform_version`

## references
- https://github.com/hashicorp/setup-terraform/blob/main/action.yml#L12
