### PR TITLE
Bump atmos-get-setting

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,7 +76,7 @@ runs:
         install-wrapper: false
 
     - name: Filter Atmos Settings Value
-      uses: cloudposse/github-action-atmos-get-setting@main
+      uses: cloudposse/github-action-atmos-get-setting@v0
       id: atmos-settings
       with:
         component: ${{ inputs.component }}


### PR DESCRIPTION
## what
- Bump action version of `github-action-atmos-get-setting`

## why
- Resolve bug with describe component

## references
- https://github.com/cloudposse/github-action-atmos-get-setting/pull/6
