### PR TITLE
Added `input.plan-id` and `output.status`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,10 @@ inputs:
   component-path:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
-  plan-file:
-    description: "Full name of the plan-file to use. If not set plan-file name will be built by pattern '<stack>-<component>-<github.sha>'. Default: ''"
-    required: false
-    default: ''
+  sha:
+    description: "SHA to use when building planfile name. Default: ${{ github.sha }}"
+    required: true
+    default: ${{ github.sha }}
   terraform-apply-role:
     description: "The AWS role to be used to apply Terraform."
     required: true
@@ -106,12 +106,9 @@ runs:
       id: planfile
       shell: bash
       run: |
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ github.sha }}.planfile" | sed 's#/#_#g') 
-        if [ "${{ inputs.plan-file }}" != "" ]; then
-          PLAN_FILE="${{ inputs.plan-file }}"
-        fi
-
+        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ inputs.sha }}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
+
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
 
@@ -131,7 +128,7 @@ runs:
       with:
         action: getPlan
         planPath: ./${{ steps.planfile.outputs.plan_file }}
-        commitSHA: '8c35369fcf6cdf2b5f74e4d041598ed5f1500164'
+        commitSHA: ${{ inputs.sha }}
         component: ${{ inputs.component }}
         stack: ${{ inputs.stack }}
         tableName: ${{ inputs.terraform-state-table }}
@@ -143,7 +140,7 @@ runs:
       with:
         action: getPlan
         planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
-        commitSHA: '8c35369fcf6cdf2b5f74e4d041598ed5f1500164'
+        commitSHA: ${{ inputs.sha }}
         component: ${{ inputs.component }}
         stack: "${{ inputs.stack }}-lockfile"
         tableName: ${{ inputs.terraform-state-table }}
@@ -256,8 +253,8 @@ runs:
 
         if [ $EXIT_CODE -eq 0 ]; then
           echo "status=succeeded'" >> $GITHUB_OUTPUT
-          echo "Terraform apply executed successfully."
+          echo "Terraform apply executed successfully"
         else
           echo "status=failed" >> $GITHUB_OUTPUT
-          echo "Terraform apply failed."
+          echo "Terraform apply failed"
         fi

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,10 @@ inputs:
   component-path:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
-  plan-file:
-    description: "Plan file can be passed from outside"
-    required: false
-    default: ""
+  sha:
+    description: "Commit SHA that will be used as suffix for plan file"
+    required: true
+    default: ${{ github.sha }}
   terraform-apply-role:
     description: "The AWS role to be used to apply Terraform."
     required: true
@@ -102,12 +102,7 @@ runs:
       id: planfile
       shell: bash
       run: |
-        if [ "${{ inputs.plan-file }}" = "" ]; then
-          PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{github.sha}}.planfile" | sed 's#/#_#g') 
-        else
-          PLAN_FILE="${{ inputs.plan-file }}"
-        fi
-        
+        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{input.sha}}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
   component-path:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
+  plan-file:
+    description: "Plan file can be passed from outside"
+    required: false
+    default: ""
   terraform-apply-role:
     description: "The AWS role to be used to apply Terraform."
     required: true
@@ -98,7 +102,12 @@ runs:
       id: planfile
       shell: bash
       run: |
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{github.sha}}.planfile" | sed 's#/#_#g') 
+        if [ "${{ inputs.plan-file }}" = "" ]; then
+          PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{github.sha}}.planfile" | sed 's#/#_#g') 
+        else
+          PLAN_FILE="${{ inputs.plan-file }}"
+        fi
+        
         PLAN_FILE_PATH=$(pwd)
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -14,10 +14,10 @@ inputs:
   component-path:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
-  plan-file-suffix:
-    description: "Commit SHA that will be used as suffix for plan file"
-    required: true
-    default: ${{ github.sha }}
+  plan-file:
+    description: "Full name of the plan-file to use. If not set plan-file name will be built by pattern '<stack>-<component>-<github.sha>'. Default: ''"
+    required: false
+    default: ''
   terraform-apply-role:
     description: "The AWS role to be used to apply Terraform."
     required: true
@@ -102,7 +102,11 @@ runs:
       id: planfile
       shell: bash
       run: |
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ inputs.plan-file-suffix }}.planfile" | sed 's#/#_#g') 
+        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ github.sha }}.planfile" | sed 's#/#_#g') 
+        if [ "${{ inputs.plan-file }}" != "" ]; then
+          PLAN_FILE="${{ inputs.plan-file }}"
+        fi
+
         PLAN_FILE_PATH=$(pwd)
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -59,6 +59,10 @@ inputs:
       not supplied by the user. When running this action on github.com, the default value is sufficient. When running on
       GHES, you can pass a personal access token for github.com if you are experiencing rate limiting.
     default: ${{ github.server_url == 'https://github.com' && github.token || '' }}
+outputs:
+  status:
+    description: Apply Status. Either 'succeeded' or 'failed'
+    value: ${{ steps.apply.outputs.status }}
 
 runs:
   using: "composite"
@@ -244,3 +248,13 @@ runs:
           --output $GITHUB_STEP_SUMMARY \
           apply -- terraform apply ${{ steps.planfile.outputs.plan_file_path }}/${{ steps.planfile.outputs.plan_file }} \
           -no-color
+
+        EXIT_CODE=$?
+
+        if [ $EXIT_CODE -eq 0 ]; then
+          echo "status=succeeded'" >> $GITHUB_OUTPUT
+          echo "Terraform apply executed successfully."
+        else
+          echo "status=failed" >> $GITHUB_OUTPUT
+          echo "Terraform apply failed."
+        fi

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,10 @@ inputs:
     description: "Atmos version to use for vendoring. Default 'latest'"
     required: false
     default: 'latest'
+  atmos-config-path:
+    description: "The path to the atmos.yaml file"
+    required: false
+    default: atmos.yaml
   terraform-version:
     description: 'The version of Terraform CLI to install. Instead of full version string you can also specify constraint string starting with "<" (for example `<1.13.0`) to install the latest version satisfying the constraint. A value of `latest` will install the latest version of Terraform CLI. Defaults to `latest`.'
     default: 'latest'
@@ -67,17 +71,24 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/checkout@v3
+    - name: Checkout
+      uses: actions/checkout@v3
 
-    - uses: hashicorp/setup-terraform@v2
+    - name: Install Terraform
+      uses: hashicorp/setup-terraform@v2
       with:
         terraform_version: ${{ inputs.terraform-version }}
+        terraform_wrapper: false
 
-    - uses: actions/setup-node@v3
+    - name: Install Node
+      uses: actions/setup-node@v3
       with:
         node-version: 16
 
-    - uses: cloudposse/github-action-setup-atmos@v1
+    - name: Install Atmos
+      uses: cloudposse/github-action-setup-atmos@v1
+      env:
+       ATMOS_CLI_CONFIG_PATH: ${{inputs.atmos-config-path}}
       with:
         atmos-version: ${{ inputs.atmos-version }}
         token: ${{ inputs.token }}
@@ -91,29 +102,54 @@ runs:
         stack: ${{ inputs.stack }}
         settings-path: github.actions_enabled
 
-    - name: Check if Action is Enable
-      id: settings
+    - name: Define Job Control State Variables
+      shell: bash
+      run: |
+        echo "DEBUG_ENABLED=${{ inputs.debug }}" >> $GITHUB_ENV
+        echo "ACTIONS_ENABLED=false" >> $GITHUB_ENV
+        echo "INFRACOST_ENABLED=false" >> $GITHUB_ENV
+
+    - name: Check If GitHub Actions is Enabled For Component
       shell: bash
       run: |
         if [[ "${{ steps.atmos-settings.outputs.value }}" == "true" ]]; then
-          echo "actions_enabled=true" >> $GITHUB_OUTPUT
+          echo "ACTIONS_ENABLED=true" >> $GITHUB_ENV
         else
-          echo "actions_enabled=false" >> $GITHUB_OUTPUT
+          echo "ACTIONS_ENABLED=false" >> $GITHUB_ENV
         fi
 
-    - name: Get Planfile Name
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
-      id: planfile
+    - name: Update Global Path for tfcmt
+      if: env.ACTIONS_ENABLED == 'true'
       shell: bash
       run: |
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ inputs.plan-id }}.planfile" | sed 's#/#_#g') 
-        PLAN_FILE_PATH=$(pwd)
+        # setup-tfcmt requires this PATH update when running on self-hosted (amazon linux) https://github.com/shmokmt/actions-setup-tfcmt/blob/main/action.yml#L11C1-L12C1
+        echo "/usr/local/bin" >> $GITHUB_PATH
 
+    - name: Install tfcmt
+      if: env.ACTIONS_ENABLED == 'true'
+      uses: shmokmt/actions-setup-tfcmt@v2
+      with:
+        version: v4.4.1
+
+    - name: Define Job Variables
+      if: env.ACTIONS_ENABLED == 'true'
+      id: vars
+      shell: bash
+      run: |
+        STACK_NAME=$(echo "${{ inputs.stack }}" | sed 's#/#_#g')
+        COMPONENT_NAME=$(echo "${{ inputs.component }}" | sed 's#/#_#g')
+        COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
+        PLAN_FILE="$GITHUB_WORKSPACE/${{ inputs.component-path}}/$COMPONENT_SLUG-${{ github.sha }}.planfile"
+        LOCK_FILE="$GITHUB_WORKSPACE/${{ inputs.component-path}}/.terraform.lock.hcl"
+
+        echo "stack_name=$STACK_NAME" >> $GITHUB_OUTPUT
+        echo "component_name=$COMPONENT_NAME" >> $GITHUB_OUTPUT
+        echo "component_slug=$COMPONENT_SLUG" >> $GITHUB_OUTPUT
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
-        echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT
+        echo "lock_file=$LOCK_FILE" >> $GITHUB_OUTPUT
 
     - name: Configure State AWS Credentials
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
+      if: env.ACTIONS_ENABLED == 'true'
       uses: aws-actions/configure-aws-credentials@v2.2.0
       with:
         aws-region: ${{ inputs.aws-region }}
@@ -122,12 +158,12 @@ runs:
         mask-aws-account-id: "no"
 
     - name: Retrieve Plan
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
+      if: env.ACTIONS_ENABLED == 'true'
       uses: cloudposse/github-action-terraform-plan-storage@added-commitsha-overwrite-input
       id: retrieve-plan
       with:
         action: getPlan
-        planPath: ./${{ steps.planfile.outputs.plan_file }}
+        planPath: ${{ steps.vars.outputs.plan_file }}
         commitSHA: ${{ inputs.commit-sha }}
         component: ${{ inputs.component }}
         stack: ${{ inputs.stack }}
@@ -135,11 +171,11 @@ runs:
         bucketName: ${{ inputs.terraform-state-bucket }}
 
     - name: Retrieve Lockfile
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
+      if: env.ACTIONS_ENABLED == 'true'
       uses: cloudposse/github-action-terraform-plan-storage@added-commitsha-overwrite-input
       with:
         action: getPlan
-        planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
+        planPath: ${{ steps.vars.outputs.lock_file }}
         commitSHA: ${{ inputs.commit-sha }}
         component: ${{ inputs.component }}
         stack: "${{ inputs.stack }}-lockfile"
@@ -147,7 +183,7 @@ runs:
         bucketName: ${{ inputs.terraform-state-bucket }}
 
     - name: Configure Apply AWS Credentials
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
+      if: env.ACTIONS_ENABLED == 'true'
       uses: aws-actions/configure-aws-credentials@v2.2.0
       with:
         aws-region: ${{ inputs.aws-region }}
@@ -155,62 +191,54 @@ runs:
         role-session-name: "atmos-terraform-apply-gitops"
         mask-aws-account-id: "no"
 
-    # setup-tfcmt requires this PATH update when running on self-hosted (amazon linux)
-    # https://github.com/shmokmt/actions-setup-tfcmt/blob/main/action.yml#L11C1-L12C1
-    - name: Update path
-      shell: bash
-      run: |
-        echo "/usr/local/bin" >> $GITHUB_PATH
-
-    - name: Setup tfcmt
-      uses: shmokmt/actions-setup-tfcmt@v2
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
-      with:
-        version: v4.4.1
-
     - name: Atmos Setup Workspace
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
+      if: env.ACTIONS_ENABLED == 'true'
       id: atmos-init
       shell: bash
       run: |
         ATMOS_BASE_PATH=$GITHUB_WORKSPACE atmos terraform workspace ${{ inputs.component }} -s ${{ inputs.stack }}
 
+    - name: Check Whether Infracost is Enabled
+      if: env.ACTIONS_ENABLED == 'true'
+      shell: bash
+      run: |
+        if [[ "${{ inputs.enable-infracost }}" == "true" ]]; then
+          echo "INFRACOST_ENABLED=true" >> $GITHUB_ENV
+        else
+          echo "INFRACOST_ENABLED=false" >> $GITHUB_ENV
+        fi
+
     - name: Setup Infracost
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(inputs.enable-infracost) }}
+      if: env.INFRACOST_ENABLED == 'true'
       uses: infracost/actions/setup@v2
       with:
         api-key: ${{ inputs.infracost-api-key }}
 
-    - name: Generate Infracost diff
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(inputs.enable-infracost) }}
+    - name: Generate Infracost Diff
+      if: env.INFRACOST_ENABLED == 'true'
       shell: bash
       run: |
-        PLAN_FILE="${{ steps.planfile.outputs.plan_file_path }}/${{ steps.planfile.outputs.plan_file }}"
-        PLAN_FILE_JSON="${{ steps.planfile.outputs.plan_file_path }}/${{ steps.planfile.outputs.plan_file }}.json"
-
-        cd ${{ inputs.component-path }}
-        terraform show -json $PLAN_FILE > $PLAN_FILE_JSON
-
         infracost diff \
-          --path=$PLAN_FILE_JSON \
+          --path="${{ steps.vars.outputs.plan_file }}.json" \
           --format=diff \
-          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+          --project-name "${{ inputs.stack }}-${{ inputs.component }}" \
           --out-file=/tmp/infracost.txt
         infracost diff \
-          --path=$PLAN_FILE_JSON \
+          --path="${{ steps.vars.outputs.plan_file }}.json" \
           --format=json \
-          --project-name ${{ inputs.stack }}-${{ inputs.component }} \
+          --project-name "${{ inputs.stack }}-${{ inputs.component }}" \
           --out-file=/tmp/infracost.json
 
-    - if: ${{ fromJSON(steps.settings.outputs.actions_enabled) && fromJSON(inputs.enable-infracost) && fromJSON(inputs.debug) }}
+    - name: Debug Infracost
+      if: env.INFRACOST_ENABLED == 'true' && env.DEBUG_ENABLED == 'true'
       shell: bash
       run: |
-        cat ${{ steps.planfile.outputs.plan_file_path }}/${{ steps.planfile.outputs.plan_file }}.json
+        cat ${{ steps.vars.outputs.plan_file }}.json
         cat /tmp/infracost.txt
         cat /tmp/infracost.json
 
-    - name: Set infracost variables
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
+    - name: Set Infracost Variables
+      if: env.INFRACOST_ENABLED == 'true'
       id: infracost-diff
       shell: bash
       run: |
@@ -226,7 +254,7 @@ runs:
         echo "infracost_diff_total_monthly_cost=$INFRACOST_DIFF_TOTAL_MONTHLY_COST" >> "$GITHUB_OUTPUT"
 
     - name: Terraform Apply
-      if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
+      if: env.ACTIONS_ENABLED == 'true'
       id: apply
       shell: bash
       continue-on-error: true
@@ -243,11 +271,9 @@ runs:
           -var "job:${{ github.job }}" \
           -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
           -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
-          --output "${{ github.workspace }}/summary-${{ github.sha }}.md" \
+          --output "$GITHUB_STEP_SUMMARY" \
           --log-level $([[ "${{ inputs.debug }}" == "true" ]] && echo "DEBUG" || echo "INFO") \
-          apply -- terraform apply ${{ steps.planfile.outputs.plan_file_path }}/${{ steps.planfile.outputs.plan_file }} || EXIT_CODE=$?
-
-        cat "${{ github.workspace }}/summary-${{ github.sha }}.md" >> $GITHUB_STEP_SUMMARY
+          apply -- terraform apply ${{ steps.vars.outputs.plan_file }} || EXIT_CODE=$?
 
         if [ $EXIT_CODE -eq 0 ]; then
           echo "status=succeeded" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -248,10 +248,10 @@ runs:
           -var "job:${{ github.job }}" \
           -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
           -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
-          --output "summary-${{ github.sha }}.md" \
+          --output "${{ github.workspace }}/summary-${{ github.sha }}.md" \
           apply -- terraform apply ${{ steps.planfile.outputs.plan_file_path }}/${{ steps.planfile.outputs.plan_file }} || EXIT_CODE=$?
 
-        cat "summary-${{ github.sha }}.md" >> $GITHUB_STEP_SUMMARY
+        cat "${{ github.workspace }}/summary-${{ github.sha }}.md" >> $GITHUB_STEP_SUMMARY
 
         if [ $EXIT_CODE -eq 0 ]; then
           echo "status=succeeded'" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -102,7 +102,7 @@ runs:
       id: planfile
       shell: bash
       run: |
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{input.sha}}.planfile" | sed 's#/#_#g') 
+        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{inputs.sha}}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,8 @@ inputs:
   component-path:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
-  plan-id:
-    description: "Suffix that will be used for plan file name to uniquely identify it. Default: github.sha"
+  commit-sha:
+    description: "Commit SHA to apply. Default: github.sha"
     required: true
     default: "${{ github.sha }}"
   terraform-apply-role:
@@ -128,7 +128,7 @@ runs:
       with:
         action: getPlan
         planPath: ./${{ steps.planfile.outputs.plan_file }}
-        commitSHA: ${{ inputs.plan-id }}
+        commitSHA: ${{ inputs.commit-sha }}
         component: ${{ inputs.component }}
         stack: ${{ inputs.stack }}
         tableName: ${{ inputs.terraform-state-table }}
@@ -140,7 +140,7 @@ runs:
       with:
         action: getPlan
         planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
-        commitSHA: ${{ inputs.plan-id }}
+        commitSHA: ${{ inputs.commit-sha }}
         component: ${{ inputs.component }}
         stack: "${{ inputs.stack }}-lockfile"
         tableName: ${{ inputs.terraform-state-table }}

--- a/action.yml
+++ b/action.yml
@@ -15,9 +15,9 @@ inputs:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
   sha:
-    description: "SHA to use when building planfile name. Default: ${{ github.sha }}"
+    description: "SHA to use when building planfile name. Default: github.sha"
     required: true
-    default: ${{ github.sha }}
+    default: "${{ github.sha }}"
   terraform-apply-role:
     description: "The AWS role to be used to apply Terraform."
     required: true

--- a/action.yml
+++ b/action.yml
@@ -242,7 +242,6 @@ runs:
         cd ${{ inputs.component-path }}
 
         EXIT_CODE=0
-        APPLY_OUTPUT=''
 
         tfcmt \
           --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
@@ -252,10 +251,10 @@ runs:
           -var "job:${{ github.job }}" \
           -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
           -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
-          --output $APPLY_OUTPUT \
+          --output "${{ github.action_path }}/output.md" \
           apply -- terraform apply ${{ steps.planfile.outputs.plan_file_path }}/${{ steps.planfile.outputs.plan_file }} || EXIT_CODE=$?
 
-        echo "$APPLY_OUTPUT" >> $GITHUB_STEP_SUMMARY
+        cat "${{ github.action_path }}/output.md" >> $GITHUB_STEP_SUMMARY
 
         if [ $EXIT_CODE -eq 0 ]; then
           echo "status=succeeded'" >> $GITHUB_OUTPUT
@@ -265,4 +264,4 @@ runs:
           echo "Terraform apply failed"
         fi
 
-        echo "summary=$APPLY_OUTPUT" >> $GITHUB_OUTPUT
+        echo "summary=$(cat "${{ github.action_path }}/output.md")" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -143,6 +143,7 @@ runs:
       with:
         action: getPlan
         planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
+        commitSHA: '8c35369fcf6cdf2b5f74e4d041598ed5f1500164'
         component: ${{ inputs.component }}
         stack: "${{ inputs.stack }}-lockfile"
         tableName: ${{ inputs.terraform-state-table }}

--- a/action.yml
+++ b/action.yml
@@ -63,6 +63,9 @@ outputs:
   status:
     description: Apply Status. Either 'succeeded' or 'failed'
     value: ${{ steps.apply.outputs.status }}
+  summary:
+    description: Terraform apply summary
+    value: ${{ steps.apply.outputs.summary }}    
 
 runs:
   using: "composite"
@@ -239,6 +242,7 @@ runs:
         cd ${{ inputs.component-path }}
 
         EXIT_CODE=0
+        APPLY_OUTPUT=''
 
         tfcmt \
           --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
@@ -248,8 +252,10 @@ runs:
           -var "job:${{ github.job }}" \
           -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
           -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
-          --output $GITHUB_STEP_SUMMARY \
+          --output $APPLY_OUTPUT \
           apply -- terraform apply ${{ steps.planfile.outputs.plan_file_path }}/${{ steps.planfile.outputs.plan_file }} || EXIT_CODE=$?
+
+        echo "$APPLY_OUTPUT" >> $GITHUB_STEP_SUMMARY
 
         if [ $EXIT_CODE -eq 0 ]; then
           echo "status=succeeded'" >> $GITHUB_OUTPUT
@@ -258,3 +264,5 @@ runs:
           echo "status=failed" >> $GITHUB_OUTPUT
           echo "Terraform apply failed"
         fi
+
+        echo "summary=$APPLY_OUTPUT" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -232,6 +232,7 @@ runs:
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
       id: apply
       shell: bash
+      continue-on-error: true
       run: |
         if [[ "${{ inputs.debug }}" == "true" ]]; then
           LOG_LEVEL="DEBUG"
@@ -239,6 +240,9 @@ runs:
           LOG_LEVEL="INFO"
         fi
         cd ${{ inputs.component-path }}
+
+        EXIT_CODE=0
+
         tfcmt \
           --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
           -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
@@ -248,10 +252,7 @@ runs:
           -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
           -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
           --output $GITHUB_STEP_SUMMARY \
-          apply -- terraform apply ${{ steps.planfile.outputs.plan_file_path }}/${{ steps.planfile.outputs.plan_file }} \
-          -no-color
-
-        EXIT_CODE=$?
+          apply -- terraform apply ${{ steps.planfile.outputs.plan_file_path }}/${{ steps.planfile.outputs.plan_file }} || EXIT_CODE=$?
 
         if [ $EXIT_CODE -eq 0 ]; then
           echo "status=succeeded'" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -139,7 +139,7 @@ runs:
 
     - name: Retrieve Lockfile
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
-      uses: cloudposse/github-action-terraform-plan-storage@v1
+      uses: cloudposse/github-action-terraform-plan-storage@added-commitsha-overwrite-input
       with:
         action: getPlan
         planPath: ${{ inputs.component-path}}/.terraform.lock.hcl

--- a/action.yml
+++ b/action.yml
@@ -231,11 +231,6 @@ runs:
       shell: bash
       continue-on-error: true
       run: |
-        if [[ "${{ inputs.debug }}" == "true" ]]; then
-          LOG_LEVEL="DEBUG"
-        else
-          LOG_LEVEL="INFO"
-        fi
         cd ${{ inputs.component-path }}
 
         EXIT_CODE=0
@@ -249,6 +244,7 @@ runs:
           -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
           -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
           --output "${{ github.workspace }}/summary-${{ github.sha }}.md" \
+          --log-level $([[ "${{ inputs.debug }}" == "true" ]] && echo "DEBUG" || echo "INFO") \
           apply -- terraform apply ${{ steps.planfile.outputs.plan_file_path }}/${{ steps.planfile.outputs.plan_file }} || EXIT_CODE=$?
 
         cat "${{ github.workspace }}/summary-${{ github.sha }}.md" >> $GITHUB_STEP_SUMMARY

--- a/action.yml
+++ b/action.yml
@@ -126,11 +126,12 @@ runs:
 
     - name: Retrieve Plan
       if: ${{ fromJSON(steps.settings.outputs.actions_enabled) }}
-      uses: cloudposse/github-action-terraform-plan-storage@v1
+      uses: cloudposse/github-action-terraform-plan-storage@added-commitsha-overwrite-input
       id: retrieve-plan
       with:
         action: getPlan
         planPath: ./${{ steps.planfile.outputs.plan_file }}
+        commitSHA: '8c35369fcf6cdf2b5f74e4d041598ed5f1500164'
         component: ${{ inputs.component }}
         stack: ${{ inputs.stack }}
         tableName: ${{ inputs.terraform-state-table }}

--- a/action.yml
+++ b/action.yml
@@ -250,7 +250,7 @@ runs:
         cat "${{ github.workspace }}/summary-${{ github.sha }}.md" >> $GITHUB_STEP_SUMMARY
 
         if [ $EXIT_CODE -eq 0 ]; then
-          echo "status=succeeded'" >> $GITHUB_OUTPUT
+          echo "status=succeeded" >> $GITHUB_OUTPUT
           echo "Terraform apply executed successfully"
         else
           echo "status=failed" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
   component-path:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
-  sha:
+  plan-file-suffix:
     description: "Commit SHA that will be used as suffix for plan file"
     required: true
     default: ${{ github.sha }}
@@ -102,7 +102,7 @@ runs:
       id: planfile
       shell: bash
       run: |
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{inputs.sha}}.planfile" | sed 's#/#_#g') 
+        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ inputs.plan-file-suffix }}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
         echo "plan_file_path=$PLAN_FILE_PATH" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -63,9 +63,6 @@ outputs:
   status:
     description: Apply Status. Either 'succeeded' or 'failed'
     value: ${{ steps.apply.outputs.status }}
-  summary:
-    description: Terraform apply summary
-    value: ${{ steps.apply.outputs.summary }}    
 
 runs:
   using: "composite"
@@ -251,10 +248,10 @@ runs:
           -var "job:${{ github.job }}" \
           -var "infracost_details_diff_breakdown:${{ steps.infracost-diff.outputs.infracost_details_diff_breakdown }}" \
           -var "infracost_total_monthly_cost:${{ steps.infracost-diff.outputs.infracost_diff_total_monthly_cost }}" \
-          --output "${{ github.action_path }}/output.md" \
+          --output "summary-${{ github.sha }}.md" \
           apply -- terraform apply ${{ steps.planfile.outputs.plan_file_path }}/${{ steps.planfile.outputs.plan_file }} || EXIT_CODE=$?
 
-        cat "${{ github.action_path }}/output.md" >> $GITHUB_STEP_SUMMARY
+        cat "summary-${{ github.sha }}.md" >> $GITHUB_STEP_SUMMARY
 
         if [ $EXIT_CODE -eq 0 ]; then
           echo "status=succeeded'" >> $GITHUB_OUTPUT
@@ -263,7 +260,3 @@ runs:
           echo "status=failed" >> $GITHUB_OUTPUT
           echo "Terraform apply failed"
         fi
-
-        summary=$(cat "${{ github.action_path }}/output.md")
-
-        echo "summary=$summary" >> $GITHUB_OUTPUT

--- a/action.yml
+++ b/action.yml
@@ -14,8 +14,8 @@ inputs:
   component-path:
     description: "The path to the base component. Atmos defines this value as component_path."
     required: true
-  sha:
-    description: "SHA to use when building planfile name. Default: github.sha"
+  plan-id:
+    description: "Suffix that will be used for plan file name to uniquely identify it. Default: github.sha"
     required: true
     default: "${{ github.sha }}"
   terraform-apply-role:
@@ -106,7 +106,7 @@ runs:
       id: planfile
       shell: bash
       run: |
-        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ inputs.sha }}.planfile" | sed 's#/#_#g') 
+        PLAN_FILE=$(echo "${{ inputs.stack }}-${{ inputs.component }}-${{ inputs.plan-id }}.planfile" | sed 's#/#_#g') 
         PLAN_FILE_PATH=$(pwd)
 
         echo "plan_file=$PLAN_FILE" >> $GITHUB_OUTPUT
@@ -128,7 +128,7 @@ runs:
       with:
         action: getPlan
         planPath: ./${{ steps.planfile.outputs.plan_file }}
-        commitSHA: ${{ inputs.sha }}
+        commitSHA: ${{ inputs.plan-id }}
         component: ${{ inputs.component }}
         stack: ${{ inputs.stack }}
         tableName: ${{ inputs.terraform-state-table }}
@@ -140,7 +140,7 @@ runs:
       with:
         action: getPlan
         planPath: ${{ inputs.component-path}}/.terraform.lock.hcl
-        commitSHA: ${{ inputs.sha }}
+        commitSHA: ${{ inputs.plan-id }}
         component: ${{ inputs.component }}
         stack: "${{ inputs.stack }}-lockfile"
         tableName: ${{ inputs.terraform-state-table }}

--- a/action.yml
+++ b/action.yml
@@ -264,4 +264,6 @@ runs:
           echo "Terraform apply failed"
         fi
 
-        echo "summary=$(cat "${{ github.action_path }}/output.md")" >> $GITHUB_OUTPUT
+        summary=$(cat "${{ github.action_path }}/output.md")
+
+        echo "summary=$summary" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## what

Added `input.plan-id` and `output.status`

## why

These inputs and outputs are required for drift remediation action and workflow.

- `input.plan-id` is a suffix that will uniquely distinguish a particular plan
- `output.status` is used in drift remediation workflow and indicates whether the apply succeeded or failed

## references

