### PR TITLE
fix: Allow failure on Errors

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -278,7 +278,6 @@ runs:
       if: env.ACTIONS_ENABLED == 'true'
       id: apply
       shell: bash
-      continue-on-error: true
       working-directory: ./${{ steps.vars.outputs.component_path }}
       run: |
         set +e


### PR DESCRIPTION
## what
- Removed `continue-on-error: true`

## why
- The action should fail when this job fails. The error we do want to continue past is already handled by `set +e / set -e`

## references
- [Internal Slack](https://cloudposse.slack.com/archives/C02M0Q4UGLC/p1708642485649819)