### PR TITLE
add atmos pro stack locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,30 @@ For more, see [Atmos GitHub Action Integrations](https://atmos.tools/integration
 
 ### Prerequisites
 
-This GitHub Action requires AWS access for two different purposes. This action will attempt to first pull a Terraform planfile from a S3 Bucket with metadata in a DynamoDB table with one role. 
-Then the action will run `terraform apply` against that component with another role. We recommend configuring 
-[OpenID Connect with AWS](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) 
-to allow GitHub to assume roles in AWS and then deploying both a Terraform Apply role and a Terraform State role. 
-For Cloud Posse documentation on setting up GitHub OIDC, see our [`github-oidc-provider` component](https://docs.cloudposse.com/components/library/aws/github-oidc-provider/).
+This GitHub Action requires AWS access for two different purposes. This action will attempt to first pull a Terraform
+planfile from a S3 Bucket with metadata in a DynamoDB table with one role. Then the action will run `terraform apply`
+against that component with another role. We recommend configuring [OpenID Connect with
+AWS](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
+to allow GitHub to assume roles in AWS and then deploying both a Terraform Apply role and a Terraform State role. For
+Cloud Posse documentation on setting up GitHub OIDC, see our [`github-oidc-provider`
+component](https://docs.cloudposse.com/components/library/aws/github-oidc-provider/).
 
-In order to retrieve Terraform Plan Files (not to be confused with Terraform State files, e.g. `tfstate`), we configure an S3 Bucket to store plan files and a DynamoDB table to track plan metadata. Both need to be deployed before running
-this action. For more on setting up those components, see the [`gitops` component](https://docs.cloudposse.com/components/library/aws/gitops/). This action will then use the [github-action-terraform-plan-storage](https://github.com/cloudposse/github-action-terraform-plan-storage) action to update these resources.
+In order to retrieve Terraform Plan Files (not to be confused with Terraform State files, e.g. `tfstate`), we
+configure an S3 Bucket to store plan files and a DynamoDB table to track plan metadata. Both need to be deployed
+before running this action. For more on setting up those components, see the [`gitops`
+component](https://docs.cloudposse.com/components/library/aws/gitops/). This action will then use the
+[github-action-terraform-plan-storage](https://github.com/cloudposse/github-action-terraform-plan-storage) action to
+update these resources.
+
+### Atmos Pro
+
+If you are using the stack locking feature of this action (setting `lock-stack` to `true`), you will need to sign up
+for an [Atmos Pro](https://app.cloudposse.com) account and generate an API key. You can then set the `atmos-pro-token`
+input variable to the value of your API key. If you are an enterprise customer and using a dedicated Atmos Pro
+instance, you should also set the `atmos-pro-base-url` input variable to the base URL of your Atmos Pro instance.
+
+> [!IMPORTANT] > **Please note!** If you are using stack locking, this GitHub Action only works with `atmos >=
+1.XX.0`. If you are using `atmos < 1.XX.0` stack locking will not work..
 
 ### Config
 
@@ -75,7 +91,7 @@ The config should have the following structure:
 integrations:
   github:
     gitops:
-      opentofu-version: 1.7.3  
+      opentofu-version: 1.7.3
       terraform-version: 1.5.2
       infracost-enabled: false
       artifact-storage:
@@ -92,7 +108,7 @@ integrations:
 ```
 
 > [!IMPORTANT]
-> **Please note!** This GitHub Action only works with `atmos >= 1.63.0`. If you are using `atmos < 1.63.0` please use `v1` version of this action.      
+> **Please note!** This GitHub Action only works with `atmos >= 1.63.0`. If you are using `atmos < 1.63.0` please use `v1` version of this action.
 
 ### Support OpenTofu
 
@@ -121,13 +137,13 @@ integrations:
     gitops:
       opentofu-version: 1.7.3
       ...
-```  
+```
 
 ### Workflow example
 
-In this example, the action is triggered when certain events occur, such as a manual workflow dispatch or the opening, synchronization, or reopening of a pull request, specifically on the main branch. It specifies specific permissions related to assuming roles in AWS. Within the "apply" job, the "component" and "stack" are hardcoded (`foobar` and `plat-ue2-sandbox`). In practice, these are usually derived from another action. 
+In this example, the action is triggered when certain events occur, such as a manual workflow dispatch or the opening, synchronization, or reopening of a pull request, specifically on the main branch. It specifies specific permissions related to assuming roles in AWS. Within the "apply" job, the "component" and "stack" are hardcoded (`foobar` and `plat-ue2-sandbox`). In practice, these are usually derived from another action.
 
-> [!TIP] 
+> [!TIP]
 We recommend combining this action with the [`affected-stacks`](https://atmos.tools/integrations/github-actions/affected-stacks) GitHub Action inside a matrix to plan all affected stacks in parallel.
 
 ```yaml
@@ -178,7 +194,7 @@ The following configuration fields moved to the `atmos.yaml` configuration file.
 
 |              name        |    YAML path in `atmos.yaml`                    |
 |--------------------------|-------------------------------------------------|
-| `aws-region`             | `integrations.github.gitops.artifact-storage.region`     | 
+| `aws-region`             | `integrations.github.gitops.artifact-storage.region`     |
 | `terraform-state-bucket` | `integrations.github.gitops.artifact-storage.bucket`     |
 | `terraform-state-table`  | `integrations.github.gitops.artifact-storage.table`      |
 | `terraform-state-role`   | `integrations.github.gitops.artifact-storage.role`       |
@@ -223,7 +239,7 @@ integrations:
       stack: "plat-ue2-sandbox"
       atmos-config-path: ./rootfs/usr/local/etc/atmos/
       atmos-version: 1.63.0
-``` 
+```
 
 This corresponds to the `v1` configuration (deprecated) below.
 
@@ -241,7 +257,7 @@ terraform-version: 1.5.2
 aws-region: us-east-2
 enable-infracost: false
 sort-by: .stack_slug
-group-by: .stack_slug | split("-") | [.[0], .[2]] | join("-")  
+group-by: .stack_slug | split("-") | [.[0], .[2]] | join("-")
 ```
 
 And the `v1` GitHub Action Workflow looked like this.
@@ -322,12 +338,15 @@ Which would produce the same behavior as in `v0`, doing this:
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
 | atmos-config-path | The path to the atmos.yaml file | N/A | true |
+| atmos-pro-base-url | The base URL for Atmos Pro | https://app.cloudposse.com | false |
+| atmos-pro-token | Your API key for Atmos Pro | N/A | false |
 | atmos-version | The version of atmos to install | >= 1.63.0 | false |
 | branding-logo-image | Branding logo image url | https://cloudposse.com/logo-300x69.svg | false |
 | branding-logo-url | Branding logo url | https://cloudposse.com/ | false |
 | component | The name of the component to apply. | N/A | true |
 | debug | Enable action debug mode. Default: 'false' | false | false |
 | infracost-api-key | Infracost API key | N/A | false |
+| lock-stack | Flag to indicate if Atmos Pro stack locking should be used | false | true |
 | sha | Commit SHA to apply. Default: github.sha | ${{ github.event.pull\_request.head.sha }} | true |
 | stack | The stack name for the given component. | N/A | true |
 | token | Used to pull node distributions for Atmos from Cloud Posse's GitHub repository. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. | ${{ github.server\_url == 'https://github.com' && github.token \|\| '' }} | false |

--- a/README.yaml
+++ b/README.yaml
@@ -49,25 +49,41 @@ references:
 usage: |-
   ### Prerequisites
 
-  This GitHub Action requires AWS access for two different purposes. This action will attempt to first pull a Terraform planfile from a S3 Bucket with metadata in a DynamoDB table with one role. 
-  Then the action will run `terraform apply` against that component with another role. We recommend configuring 
-  [OpenID Connect with AWS](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) 
-  to allow GitHub to assume roles in AWS and then deploying both a Terraform Apply role and a Terraform State role. 
-  For Cloud Posse documentation on setting up GitHub OIDC, see our [`github-oidc-provider` component](https://docs.cloudposse.com/components/library/aws/github-oidc-provider/).
+  This GitHub Action requires AWS access for two different purposes. This action will attempt to first pull a Terraform
+  planfile from a S3 Bucket with metadata in a DynamoDB table with one role. Then the action will run `terraform apply`
+  against that component with another role. We recommend configuring [OpenID Connect with
+  AWS](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
+  to allow GitHub to assume roles in AWS and then deploying both a Terraform Apply role and a Terraform State role. For
+  Cloud Posse documentation on setting up GitHub OIDC, see our [`github-oidc-provider`
+  component](https://docs.cloudposse.com/components/library/aws/github-oidc-provider/).
 
-  In order to retrieve Terraform Plan Files (not to be confused with Terraform State files, e.g. `tfstate`), we configure an S3 Bucket to store plan files and a DynamoDB table to track plan metadata. Both need to be deployed before running
-  this action. For more on setting up those components, see the [`gitops` component](https://docs.cloudposse.com/components/library/aws/gitops/). This action will then use the [github-action-terraform-plan-storage](https://github.com/cloudposse/github-action-terraform-plan-storage) action to update these resources.
+  In order to retrieve Terraform Plan Files (not to be confused with Terraform State files, e.g. `tfstate`), we
+  configure an S3 Bucket to store plan files and a DynamoDB table to track plan metadata. Both need to be deployed
+  before running this action. For more on setting up those components, see the [`gitops`
+  component](https://docs.cloudposse.com/components/library/aws/gitops/). This action will then use the
+  [github-action-terraform-plan-storage](https://github.com/cloudposse/github-action-terraform-plan-storage) action to
+  update these resources.
+
+  ### Atmos Pro
+
+  If you are using the stack locking feature of this action (setting `lock-stack` to `true`), you will need to sign up
+  for an [Atmos Pro](https://app.cloudposse.com) account and generate an API key. You can then set the `atmos-pro-token`
+  input variable to the value of your API key. If you are an enterprise customer and using a dedicated Atmos Pro
+  instance, you should also set the `atmos-pro-base-url` input variable to the base URL of your Atmos Pro instance.
+
+  > [!IMPORTANT] > **Please note!** If you are using stack locking, this GitHub Action only works with `atmos >=
+  1.XX.0`. If you are using `atmos < 1.XX.0` stack locking will not work..
 
   ### Config
 
   The action expects the atmos configuration file `atmos.yaml` to be present in the repository.
   The config should have the following structure:
-  
+
   ```yaml
   integrations:
     github:
       gitops:
-        opentofu-version: 1.7.3  
+        opentofu-version: 1.7.3
         terraform-version: 1.5.2
         infracost-enabled: false
         artifact-storage:
@@ -82,44 +98,44 @@ usage: |-
           sort-by: .stack_slug
           group-by: .stack_slug | split("-") | [.[0], .[2]] | join("-")
   ```
-  
+
   > [!IMPORTANT]
-  > **Please note!** This GitHub Action only works with `atmos >= 1.63.0`. If you are using `atmos < 1.63.0` please use `v1` version of this action.      
-  
+  > **Please note!** This GitHub Action only works with `atmos >= 1.63.0`. If you are using `atmos < 1.63.0` please use `v1` version of this action.
+
   ### Support OpenTofu
-  
+
   This action supports [OpenTofu](https://opentofu.org/).
-  
+
   > [!IMPORTANT]
   > **Please note!** OpenTofu supported by Atmos `>= 1.73.0`.
   > For details [read](https://atmos.tools/core-concepts/projects/configuration/opentofu/)
-  
+
   To enable OpenTofu add the following settings to `atmos.yaml`
     * Set the `opentofu-version` in the `atmos.yaml` to the desired version
     * Set `components.terraform.command` to `tofu`
-  
+
   #### Example
-  
+
   ```yaml
-  
+
   components:
     terraform:
       command: tofu
-  
+
   ...
-  
+
   integrations:
     github:
       gitops:
         opentofu-version: 1.7.3
         ...
-  ```  
+  ```
 
   ### Workflow example
 
-  In this example, the action is triggered when certain events occur, such as a manual workflow dispatch or the opening, synchronization, or reopening of a pull request, specifically on the main branch. It specifies specific permissions related to assuming roles in AWS. Within the "apply" job, the "component" and "stack" are hardcoded (`foobar` and `plat-ue2-sandbox`). In practice, these are usually derived from another action. 
-  
-  > [!TIP] 
+  In this example, the action is triggered when certain events occur, such as a manual workflow dispatch or the opening, synchronization, or reopening of a pull request, specifically on the main branch. It specifies specific permissions related to assuming roles in AWS. Within the "apply" job, the "component" and "stack" are hardcoded (`foobar` and `plat-ue2-sandbox`). In practice, these are usually derived from another action.
+
+  > [!TIP]
   We recommend combining this action with the [`affected-stacks`](https://atmos.tools/integrations/github-actions/affected-stacks) GitHub Action inside a matrix to plan all affected stacks in parallel.
 
   ```yaml
@@ -151,26 +167,26 @@ usage: |-
   ```
 
   ### Migrating from `v1` to `v2`
-  
+
   The notable changes in `v2` are:
-  
+
   - `v2` works only with `atmos >= 1.63.0`
   - `v2` drops `install-terraform` input because terraform is not required for affected stacks call
   - `v2` drops `atmos-gitops-config-path` input and the `./.github/config/atmos-gitops.yaml` config file. Now you have to use GitHub Actions environment variables to specify the location of the `atmos.yaml`.
-  
+
   The following configuration fields now moved to GitHub action inputs with the same names
-  
+
   |         name            |
   |-------------------------|
   | `atmos-version`         |
   | `atmos-config-path`     |
-  
-  
+
+
   The following configuration fields moved to the `atmos.yaml` configuration file.
-  
+
   |              name        |    YAML path in `atmos.yaml`                    |
   |--------------------------|-------------------------------------------------|
-  | `aws-region`             | `integrations.github.gitops.artifact-storage.region`     | 
+  | `aws-region`             | `integrations.github.gitops.artifact-storage.region`     |
   | `terraform-state-bucket` | `integrations.github.gitops.artifact-storage.bucket`     |
   | `terraform-state-table`  | `integrations.github.gitops.artifact-storage.table`      |
   | `terraform-state-role`   | `integrations.github.gitops.artifact-storage.role`       |
@@ -180,14 +196,14 @@ usage: |-
   | `enable-infracost`       |  `integrations.github.gitops.infracost-enabled` |
   | `sort-by`                |  `integrations.github.gitops.matrix.sort-by`    |
   | `group-by`               |  `integrations.github.gitops.matrix.group-by`   |
-  
-  
+
+
   For example, to migrate from `v1` to `v2`, you should have something similar to the following in your `atmos.yaml`:
-  
+
   `./.github/config/atmos.yaml`
   ```yaml
   # ... your existing configuration
-  
+
   integrations:
     github:
       gitops:
@@ -205,7 +221,7 @@ usage: |-
           sort-by: .stack_slug
           group-by: .stack_slug | split("-") | [.[0], .[2]] | join("-")
   ```
-  
+
   `.github/workflows/main.yaml`
   ```yaml
     - name: Plan Atmos Component
@@ -215,12 +231,12 @@ usage: |-
         stack: "plat-ue2-sandbox"
         atmos-config-path: ./rootfs/usr/local/etc/atmos/
         atmos-version: 1.63.0
-  ``` 
-  
+  ```
+
   This corresponds to the `v1` configuration (deprecated) below.
-  
+
   The `v1` configuration file `./.github/config/atmos-gitops.yaml` looked like this:
-  
+
   ```yaml
   atmos-version: 1.45.3
   atmos-config-path: ./rootfs/usr/local/etc/atmos/
@@ -233,11 +249,11 @@ usage: |-
   aws-region: us-east-2
   enable-infracost: false
   sort-by: .stack_slug
-  group-by: .stack_slug | split("-") | [.[0], .[2]] | join("-")  
+  group-by: .stack_slug | split("-") | [.[0], .[2]] | join("-")
   ```
-  
+
   And the `v1` GitHub Action Workflow looked like this.
-  
+
   `.github/workflows/main.yaml`
   ```yaml
     - name: Plan Atmos Component
@@ -247,9 +263,9 @@ usage: |-
         stack: "plat-ue2-sandbox"
         atmos-gitops-config-path: ./.github/config/atmos-gitops.yaml
   ```
-  
+
   ### Migrating from `v0` to `v1`
-  
+
   1. `v1` drops the `component-path` variable and instead fetches if directly from the [`atmos.yaml` file](https://atmos.tools/cli/configuration/) automatically. Simply remove the `component-path` argument from your invocations of the `cloudposse/github-action-atmos-terraform-apply` action.
   2. `v1` moves most of the `inputs` to the Atmos GitOps config path `./.github/config/atmos-gitops.yaml`. Simply create this file, transfer your settings to it, then remove the corresponding arguments from your invocations of the `cloudposse/github-action-atmos-terraform-apply` action.
 
@@ -265,10 +281,10 @@ usage: |-
   | `terraform-version`      |
   | `aws-region`             |
   | `enable-infracost`       |
-  
-  
+
+
   If you want the same behavior in `v1` as in `v0` you should create config `./.github/config/atmos-gitops.yaml` with the same variables as in `v0` inputs.
-  
+
   ```yaml
   - name: Terraform apply
     uses: cloudposse/github-action-atmos-terraform-apply@v1
@@ -277,9 +293,9 @@ usage: |-
       component: "foobar"
       stack: "plat-ue2-sandbox"
   ```
-  
+
   Which would produce the same behavior as in `v0`, doing this:
-  
+
   ```yaml
   - name: Terraform apply
     uses: cloudposse/github-action-atmos-terraform-apply@v0

--- a/action.yml
+++ b/action.yml
@@ -1,9 +1,9 @@
-name: 'GitHub Action Atmos Terraform Apply'
-description: 'GitHub Action Atmos Terraform Apply'
+name: "GitHub Action Atmos Terraform Apply"
+description: "GitHub Action Atmos Terraform Apply"
 author: hello@cloudposse.com
 branding:
-  icon: 'server'
-  color: 'white'
+  icon: "server"
+  color: "white"
 inputs:
   component:
     description: "The name of the component to apply."
@@ -22,6 +22,17 @@ inputs:
   atmos-config-path:
     description: The path to the atmos.yaml file
     required: true
+  lock-stack:
+    description: "Flag to indicate if Atmos Pro stack locking should be used"
+    required: true
+    default: "false"
+  atmos-pro-token:
+    description: Your API key for Atmos Pro
+    required: false
+  atmos-pro-base-url:
+    description: The base URL for Atmos Pro
+    required: false
+    default: "https://app.cloudposse.com"
   infracost-api-key:
     description: "Infracost API key"
     required: false
@@ -35,7 +46,7 @@ inputs:
     default: "https://cloudposse.com/"
   debug:
     description: "Enable action debug mode. Default: 'false'"
-    default: 'false'
+    default: "false"
     required: false
   token:
     description:
@@ -75,13 +86,13 @@ runs:
       shell: bash
       id: config
       run: |-
-        echo "opentofu-version=$(atmos describe config -f json | jq -r '.integrations.github.gitops["opentofu-version"]')" >> $GITHUB_OUTPUT        
+        echo "opentofu-version=$(atmos describe config -f json | jq -r '.integrations.github.gitops["opentofu-version"]')" >> $GITHUB_OUTPUT
         echo "terraform-version=$(atmos describe config -f json | jq -r '.integrations.github.gitops["terraform-version"]')" >> $GITHUB_OUTPUT
-        echo "enable-infracost=$(atmos describe config -f json | jq -r '.integrations.github.gitops["infracost-enabled"]')" >> $GITHUB_OUTPUT        
+        echo "enable-infracost=$(atmos describe config -f json | jq -r '.integrations.github.gitops["infracost-enabled"]')" >> $GITHUB_OUTPUT
         echo "aws-region=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].region')" >> $GITHUB_OUTPUT
         echo "terraform-state-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].role')" >> $GITHUB_OUTPUT
         echo "terraform-state-table=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].table')" >> $GITHUB_OUTPUT
-        echo "terraform-state-bucket=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].bucket')" >> $GITHUB_OUTPUT        
+        echo "terraform-state-bucket=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].bucket')" >> $GITHUB_OUTPUT
         echo "terraform-plan-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops.role.plan')" >> $GITHUB_OUTPUT
         echo "terraform-apply-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops.role.apply')" >> $GITHUB_OUTPUT
 
@@ -97,7 +108,7 @@ runs:
       with:
         cache: true
         config: |-
-          opentofu/opentofu: 
+          opentofu/opentofu:
             tag: ${{ startsWith(steps.config.outputs.opentofu-version, 'v') && steps.config.outputs.opentofu-version || format('v{0}', steps.config.outputs.opentofu-version) }}
             skip: ${{ steps.config.outputs.opentofu-version == '' || steps.config.outputs.opentofu-version == 'null' }}
           suzuki-shunsuke/tfcmt: v4.11.0
@@ -145,7 +156,7 @@ runs:
       if: env.ACTIONS_ENABLED == 'true'
       shell: bash
       run: |-
-        # Set ATMOS_BASE_PATH allow `cloudposse/utils` provider to read atmos config from the correct path 
+        # Set ATMOS_BASE_PATH allow `cloudposse/utils` provider to read atmos config from the correct path
         ATMOS_BASE_PATH="${{ fromJson(steps.component.outputs.settings).base-path }}"
         echo "ATMOS_BASE_PATH=$(realpath ${ATMOS_BASE_PATH:-./})" >> $GITHUB_ENV
 
@@ -286,6 +297,16 @@ runs:
           ${{ steps.vars.outputs.component_path }}/.terraform
         key: ${{ steps.vars.outputs.cache-key }}
 
+    - name: Atmos Lock Stack
+      if: ${{ fromJson(steps.component.outputs.settings).enabled && inputs.lock-stack == 'true' }}
+      id: atmos-lock-stack
+      shell: bash
+      env:
+        ATMOS_PRO_TOKEN: ${{ inputs.atmos-pro-token }}
+        ATMOS_PRO_BASE_URL: ${{ inputs.atmos-pro-base-url }}
+      run: |
+        atmos pro lock -ttl 300 --stack ${{ inputs.stack }} --component ${{ inputs.component }} --message "Locked by GitHub Action github-action-atmos-terraform-plan. SHA of the commit that triggered the workflow: ${{ inputs.sha }}"
+
     - name: Terraform Apply
       if: env.ACTIONS_ENABLED == 'true'
       id: apply
@@ -293,7 +314,7 @@ runs:
       working-directory: ${{ steps.vars.outputs.component_path }}
       run: |
         set +e
-        
+
         TERRAFORM_OUTPUT_FILE="./terraform-${GITHUB_RUN_ID}-output.txt"
 
         tfcmt \
@@ -315,22 +336,22 @@ runs:
             -input=false \
             -no-color \
         &> ${TERRAFORM_OUTPUT_FILE}
-        
+
         TERRAFORM_RESULT=$?
 
         set -e
-                
+
         cat "${TERRAFORM_OUTPUT_FILE}"
-        atmos terraform output ${{ inputs.component }} --stack ${{ inputs.stack }} --skip-init -- -json 1> output_values.json        
+        atmos terraform output ${{ inputs.component }} --stack ${{ inputs.stack }} --skip-init -- -json 1> output_values.json
         terraform-docs -c ${{ github.action_path }}/config/tfdocs-config.yaml --output-file ${{ github.workspace }}/atmos-apply-summary.md ./
-        
+
         sed -i "s#\`<sensitive>\`#![Sensitive](https://img.shields.io/badge/sensitive-c40000?style=for-the-badge)#g" ${{ github.workspace }}/atmos-apply-summary.md
         sed -i "s#\`\"#\`#g" ${{ github.workspace }}/atmos-apply-summary.md
         sed -i "s#\"\`#\`#g" ${{ github.workspace }}/atmos-apply-summary.md
         sed -i "s#|--#|:-#g" ${{ github.workspace }}/atmos-apply-summary.md
-        
+
         cat "${{ github.workspace }}/atmos-apply-summary.md" >> $GITHUB_STEP_SUMMARY
-        
+
         if [[ "${TERRAFORM_RESULT}" == "0" ]]; then
           echo "status=succeeded" >> $GITHUB_OUTPUT
           echo "Terraform apply executed successfully"
@@ -341,7 +362,17 @@ runs:
 
         # Link to a job that executed this action
         echo "[Job](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> "${{ github.workspace }}/atmos-apply-summary.md"
-        
+
         rm -f ${TERRAFORM_OUTPUT_FILE}
-        
+
         exit $TERRAFORM_RESULT
+
+    - name: Atmos Unlock Stack
+      if: ${{ fromJson(steps.component.outputs.settings).enabled && inputs.lock-stack == 'true' }}
+      id: atmos-unlock-stack
+      shell: bash
+      env:
+        ATMOS_PRO_TOKEN: ${{ inputs.atmos-pro-token }}
+        ATMOS_PRO_BASE_URL: ${{ inputs.atmos-pro-base-url }}
+      run: |
+        atmos pro unlock --stack ${{ inputs.stack }} --component ${{ inputs.component }}

--- a/docs/github-action.md
+++ b/docs/github-action.md
@@ -5,12 +5,15 @@
 | Name | Description | Default | Required |
 |------|-------------|---------|----------|
 | atmos-config-path | The path to the atmos.yaml file | N/A | true |
+| atmos-pro-base-url | The base URL for Atmos Pro | https://app.cloudposse.com | false |
+| atmos-pro-token | Your API key for Atmos Pro | N/A | false |
 | atmos-version | The version of atmos to install | >= 1.63.0 | false |
 | branding-logo-image | Branding logo image url | https://cloudposse.com/logo-300x69.svg | false |
 | branding-logo-url | Branding logo url | https://cloudposse.com/ | false |
 | component | The name of the component to apply. | N/A | true |
 | debug | Enable action debug mode. Default: 'false' | false | false |
 | infracost-api-key | Infracost API key | N/A | false |
+| lock-stack | Flag to indicate if Atmos Pro stack locking should be used | false | true |
 | sha | Commit SHA to apply. Default: github.sha | ${{ github.event.pull\_request.head.sha }} | true |
 | stack | The stack name for the given component. | N/A | true |
 | token | Used to pull node distributions for Atmos from Cloud Posse's GitHub repository. Since there's a default, this is typically not supplied by the user. When running this action on github.com, the default value is sufficient. When running on GHES, you can pass a personal access token for github.com if you are experiencing rate limiting. | ${{ github.server\_url == 'https://github.com' && github.token \|\| '' }} | false |


### PR DESCRIPTION
## what

Add opt-in support for Atmos Pro [stack locking](https://app.cloudposse.com/docs/stack-locking)

## why

To allow consumers of this action to optionally use the Atmos Pro stack locking feature.

## references

Needs a release for https://github.com/cloudposse/atmos/pull/678 to be cut before merge.