### PR TITLE
fix: assume IAM role before running `cloudposse/github-action-atmos-get-setting`

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,7 +47,7 @@ jobs:
           component: "foobar"
           stack: "plat-ue2-sandbox"
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.81.0
+          atmos-version: 1.86.2
 
       - uses: actions/checkout@v4
         with:

--- a/action.yml
+++ b/action.yml
@@ -103,6 +103,14 @@ runs:
           suzuki-shunsuke/tfcmt: v4.11.0
           terraform-docs/terraform-docs: v0.18.0
 
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v4.0.2
+      with:
+        aws-region: ${{ steps.config.outputs.aws-region }}
+        role-to-assume: ${{ steps.config.outputs.terraform-apply-role }}
+        role-session-name: "atmos-terraform-apply-gitops"
+        mask-aws-account-id: "no"
+
     - name: Get atmos settings
       uses: cloudposse/github-action-atmos-get-setting@v1
       id: component


### PR DESCRIPTION


## what

* assume IAM role before running `cloudposse/github-action-atmos-get-setting`

## why

As of atmos `1.86.2`, when `atmos.Component` began actually retrieving the TF state, it broke `cloudposse/github-action-atmos-affected-stacks` which we resolved as part of [this release](https://github.com/cloudposse/github-action-atmos-affected-stacks/releases/tag/v3.4.0) of the aforementioned action. We just had the action assume the IAM role, and that was it. However in cases where this function is used, appropriate IAM credentials to also be a requirement for `cloudposse/github-action-atmos-get-setting`:

```bash
> Run cloudposse/github-action-atmos-get-setting@v1
template: all-atmos-sections:163:26: executing "all-atmos-sections" at <atmos.Component>: error calling Component: exit status 1

Error: error configuring S3 Backend: IAM Role (arn:aws:iam::xxxxxxxxxxxx:role/xxxx-core-gbl-root-tfstate) cannot be assumed.

There are a number of possible causes of this - the most common are:
  * The credentials used in order to assume the role are invalid
  * The credentials do not have appropriate permission to assume the role
  * The role ARN is not valid

Error: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
```

## references

https://github.com/cloudposse/atmos/releases/tag/v1.86.2

