### PR TITLE
fix: replace context with default var

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -330,7 +330,7 @@ runs:
                 
         cat "${TERRAFORM_OUTPUT_FILE}"
         atmos terraform output ${{ inputs.component }} --stack ${{ inputs.stack }} --skip-init -- -json 1> output_values.json        
-        terraform-docs -c ${{ github. }}/config/tfdocs-config.yaml --output-file ${{ github.workspace }}/atmos-apply-summary.md ./
+        terraform-docs -c ${GITHUB_ACTION_PATH}/config/tfdocs-config.yaml --output-file ${{ github.workspace }}/atmos-apply-summary.md ./
         
         sed -i "s#\`<sensitive>\`#![Sensitive](https://img.shields.io/badge/sensitive-c40000?style=for-the-badge)#g" ${{ github.workspace }}/atmos-apply-summary.md
         sed -i "s#\`\"#\`#g" ${{ github.workspace }}/atmos-apply-summary.md

--- a/action.yml
+++ b/action.yml
@@ -305,7 +305,7 @@ runs:
         TERRAFORM_OUTPUT_FILE="./terraform-${GITHUB_RUN_ID}-output.txt"
 
         tfcmt \
-          --config "${{ github.action_path }}/config/atmos_github_summary.yaml" \
+          --config "${GITHUB_ACTION_PATH}/config/atmos_github_summary.yaml" \
           -var "target:${{ inputs.stack }}-${{ inputs.component }}" \
           -var "component:${{ inputs.component }}" \
           -var "stack:${{ inputs.stack }}" \
@@ -330,7 +330,7 @@ runs:
                 
         cat "${TERRAFORM_OUTPUT_FILE}"
         atmos terraform output ${{ inputs.component }} --stack ${{ inputs.stack }} --skip-init -- -json 1> output_values.json        
-        terraform-docs -c ${{ github.action_path }}/config/tfdocs-config.yaml --output-file ${{ github.workspace }}/atmos-apply-summary.md ./
+        terraform-docs -c ${{ github. }}/config/tfdocs-config.yaml --output-file ${{ github.workspace }}/atmos-apply-summary.md ./
         
         sed -i "s#\`<sensitive>\`#![Sensitive](https://img.shields.io/badge/sensitive-c40000?style=for-the-badge)#g" ${{ github.workspace }}/atmos-apply-summary.md
         sed -i "s#\`\"#\`#g" ${{ github.workspace }}/atmos-apply-summary.md


### PR DESCRIPTION
## what
- Replace context with default variable

## why
- When using container within GitHub Actions, context value is incorrect. Default variable value remains correct.
- As github.action_path is used during step execution (within runner), it can be replaced by default variable.

## references
* https://github.com/cloudposse/github-action-atmos-affected-stacks/pull/52
* There are more reported issues showing this problem in various scenarios, for instance [this one](https://github.com/actions/runner/issues/716#issuecomment-1494213926)
