### PR TITLE
Google backend

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -193,7 +193,7 @@ runs:
         echo "lock_file=$LOCK_FILE" >> $GITHUB_OUTPUT
 
     - name: Configure State AWS Credentials
-      if: env.ACTIONS_ENABLED == 'true'
+      if: env.ACTIONS_ENABLED == 'true'&& steps.config.outputs.backend == 'aws'
       uses: aws-actions/configure-aws-credentials@v4.0.2
       with:
         aws-region: ${{ steps.config.outputs.aws-region }}

--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,12 @@ runs:
         echo "terraform-version=$(atmos describe config -f json | jq -r '.integrations.github.gitops["terraform-version"]')" >> $GITHUB_OUTPUT
         echo "enable-infracost=$(atmos describe config -f json | jq -r '.integrations.github.gitops["infracost-enabled"]')" >> $GITHUB_OUTPUT        
         echo "aws-region=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].region')" >> $GITHUB_OUTPUT
+        echo "backend=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].backend')" >> $GITHUB_OUTPUT
+        echo "google-project-id=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-project-id"')" >> $GITHUB_OUTPUT
+        echo "google-workload-identity-provider=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-workload-identity-provider"')" >> $GITHUB_OUTPUT
+        echo "google-service-account=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-service-account"')" >> $GITHUB_OUTPUT
+        echo "google-firestore-database-name=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-firestore-database-name"')" >> $GITHUB_OUTPUT
+        echo "google-firestore-collection-name=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"]."google-firestore-collection-name"')" >> $GITHUB_OUTPUT
         echo "terraform-state-role=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].role')" >> $GITHUB_OUTPUT
         echo "terraform-state-table=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].table')" >> $GITHUB_OUTPUT
         echo "terraform-state-bucket=$(atmos describe config -f json | jq -r '.integrations.github.gitops["artifact-storage"].bucket')" >> $GITHUB_OUTPUT        
@@ -105,11 +111,19 @@ runs:
 
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v4.0.2
+      if: ${{ steps.config.outputs.backend == 'aws' }}
       with:
         aws-region: ${{ steps.config.outputs.aws-region }}
         role-to-assume: ${{ steps.config.outputs.terraform-apply-role }}
         role-session-name: "atmos-terraform-apply-gitops"
         mask-aws-account-id: "no"
+
+    - name: Configure Google Credentials
+      if: ${{ steps.config.outputs.backend == 'google' }}
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ steps.config.outputs.google-workload-identity-provider }}
+        service_account: ${{ steps.config.outputs.google-service-account }}
 
     - name: Get atmos settings
       uses: cloudposse/github-action-atmos-get-setting@v1
@@ -187,10 +201,10 @@ runs:
         role-session-name: "atmos-terraform-state-gitops"
         mask-aws-account-id: "no"
 
-    - name: Retrieve Plan
-      if: env.ACTIONS_ENABLED == 'true'
+    - name: Retrieve Plan AWS
+      if: env.ACTIONS_ENABLED == 'true' && steps.config.outputs.backend == 'aws'
       uses: cloudposse/github-action-terraform-plan-storage@v1
-      id: retrieve-plan
+      id: retrieve-plan-aws
       continue-on-error: true
       with:
         action: getPlan
@@ -201,8 +215,8 @@ runs:
         tableName: ${{ steps.config.outputs.terraform-state-table }}
         bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
 
-    - name: Retrieve Lockfile
-      if: env.ACTIONS_ENABLED == 'true'
+    - name: Retrieve Lockfile AWS
+      if: env.ACTIONS_ENABLED == 'true' && steps.config.outputs.backend == 'aws'
       uses: cloudposse/github-action-terraform-plan-storage@v1
       continue-on-error: true
       with:
@@ -213,6 +227,41 @@ runs:
         stack: "${{ inputs.stack }}-lockfile"
         tableName: ${{ steps.config.outputs.terraform-state-table }}
         bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
+
+    - name: Retrieve Plan Google
+      if: env.ACTIONS_ENABLED == 'true' && steps.config.outputs.backend == 'google'
+      uses: shirkevich/github-action-terraform-plan-storage@google-cloud-backend
+      id: retrieve-plan-google
+      continue-on-error: true
+      with:
+        action: getPlan
+        planPath: ${{ steps.vars.outputs.plan_file }}
+        commitSHA: ${{ inputs.sha }}
+        component: ${{ inputs.component }}
+        stack: ${{ inputs.stack }}
+        bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
+        planRepositoryType: gcs
+        metadataRepositoryType: firestore
+        gcpProjectId: ${{ steps.config.outputs.google-project-id }}
+        gcpFirestoreDatabaseName: ${{ steps.config.outputs.google-firestore-database-name }}
+        gcpFirestoreCollectionName: ${{ steps.config.outputs.google-firestore-collection-name }}
+
+    - name: Retrieve Lockfile Google
+      if: env.ACTIONS_ENABLED == 'true' && steps.config.outputs.backend == 'google'
+      uses: shirkevich/github-action-terraform-plan-storage@google-cloud-backend
+      continue-on-error: true
+      with:
+        action: getPlan
+        planPath: ${{ steps.vars.outputs.lock_file }}
+        commitSHA: ${{ inputs.sha }}
+        component: ${{ inputs.component }}
+        stack: "${{ inputs.stack }}-lockfile"
+        bucketName: ${{ steps.config.outputs.terraform-state-bucket }}
+        planRepositoryType: gcs
+        metadataRepositoryType: firestore
+        gcpProjectId: ${{ steps.config.outputs.google-project-id }}
+        gcpFirestoreDatabaseName: ${{ steps.config.outputs.google-firestore-database-name }}
+        gcpFirestoreCollectionName: ${{ steps.config.outputs.google-firestore-collection-name }}
 
     - name: Configure AWS Credentials
       if: env.ACTIONS_ENABLED == 'true'

--- a/action.yml
+++ b/action.yml
@@ -264,7 +264,7 @@ runs:
         gcpFirestoreCollectionName: ${{ steps.config.outputs.google-firestore-collection-name }}
 
     - name: Configure AWS Credentials
-      if: env.ACTIONS_ENABLED == 'true'
+      if: env.ACTIONS_ENABLED == 'true' && steps.config.outputs.backend == 'aws'
       uses: aws-actions/configure-aws-credentials@v4.0.2
       with:
         aws-region: ${{ steps.config.outputs.aws-region }}


### PR DESCRIPTION
## what

Use google services to apply state

## why

For those who use google cloud it is hard to adopt atmos as all the GH tooling is built around AWS. This PR and several other fixes that.

## references

See also related PRs in:

* https://github.com/cloudposse/github-action-terraform-plan-storage/pull/35
* https://github.com/cloudposse/github-action-atmos-terraform-plan/pull/93
* https://github.com/cloudposse/github-action-atmos-affected-stacks/pull/55

## need help

To proper name the fields in metadata for google cloud. 