### PR TITLE
Bugfix: Process Templates false for get-settings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -80,6 +80,9 @@ runs:
       id: atmos-settings
       uses: cloudposse/github-action-atmos-get-setting@v2
       with:
+        # Here we do not process-templates because that requires terraform. Which we install after fetching the version
+        # processing templates here can cause an issue where cached terraform versions conflict with the version we want to install
+        process-templates: 'false'
         settings: |
           - component: ${{ inputs.component }}
             stack: ${{ inputs.stack }}


### PR DESCRIPTION
## what

Do not process templates when fetching settings of a component

## why

Causes an issue where terraform is expected before it is installed which can fail or cause conflicting version issues.
