### PR TITLE
fix: filter out 'Switched to workspace' message in terraform output

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -417,7 +417,7 @@ runs:
         set -e
                 
         cat "${TERRAFORM_OUTPUT_FILE}"
-        atmos terraform output ${{ inputs.component }} --stack ${{ inputs.stack }} --skip-init -- -json 1> output_values.json        
+        atmos terraform output ${{ inputs.component }} --stack ${{ inputs.stack }} --skip-init -- -json | grep -v 'Switched to workspace' 1> output_values.json        
         terraform-docs -c ${GITHUB_ACTION_PATH}/config/tfdocs-config.yaml --output-file ${{ github.workspace }}/atmos-apply-summary.md ./
         
         sed -i "s#\`<sensitive>\`#![Sensitive](https://img.shields.io/badge/sensitive-c40000?style=for-the-badge)#g" ${{ github.workspace }}/atmos-apply-summary.md


### PR DESCRIPTION
## what
 - `atmos terraform output ... -skip-init` runs `terraform workspace` && `terraform output`
 - When running and outputting to a file this leads to a json file similar to the following:
   ```
   [0m[32mSwitched to workspace "foo-bar".[0m
    {
      "bucket_arn": {
        ...
        }
    }
    ```
 - This PR adds a simple grep line to ensure that switch is removed from the json file.

## why
 - Bugfix issue with `Error: invalid character '\x1b' looking for beginning of value`


