### PR TITLE
Suppress warnings on terraform outputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -417,7 +417,10 @@ runs:
         set -e
                 
         cat "${TERRAFORM_OUTPUT_FILE}"
-        atmos terraform output ${{ inputs.component }} --stack ${{ inputs.stack }} --skip-init -- -json | grep -v 'Switched to workspace' 1> output_values.json        
+        atmos terraform output ${{ inputs.component }} --stack ${{ inputs.stack }} --skip-init -- -json -compact-warnings -no-color  | \
+          grep -v 'Switched to workspace' | \
+          awk '$1~/^Warnings:$/ {exit} {print}' | \
+          grep -v 'WARN detected' 1> output_values.json        
         terraform-docs -c ${GITHUB_ACTION_PATH}/config/tfdocs-config.yaml --output-file ${{ github.workspace }}/atmos-apply-summary.md ./
         
         sed -i "s#\`<sensitive>\`#![Sensitive](https://img.shields.io/badge/sensitive-c40000?style=for-the-badge)#g" ${{ github.workspace }}/atmos-apply-summary.md


### PR DESCRIPTION
## what
* Suppress warnings on terraform outputs


## why
* Warnings from Terraform about deprecation raised on `terraform outputs` that break output json structure
