### PR TITLE
Disable process functions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -47,7 +47,6 @@ jobs:
           component: "foobar"
           stack: "plat-ue2-sandbox"
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.99.0
 
       - uses: actions/checkout@v4
         with:
@@ -64,5 +63,4 @@ jobs:
           component: "foobar"
           stack: "plat-ue2-sandbox"
           atmos-config-path: ${{ runner.temp }}
-          atmos-version: 1.99.0
           debug: true

--- a/README.yaml
+++ b/README.yaml
@@ -62,7 +62,8 @@ usage: |-
   ### Config
 
   > [!IMPORTANT]
-  > **Please note!** This GitHub Action only works with `atmos >= 1.99.0`.
+  > **Please note!** This GitHub Action only works with `atmos >= 1.158.0`.
+  > If you are using `atmos >= 1.99.0, < 1.158.0` please use `v3` version of this action.    
   > If you are using `atmos >= 1.63.0, < 1.99.0` please use `v2` version of this action.  
   > If you are using `atmos < 1.63.0` please use `v1` version of this action.
 
@@ -211,6 +212,12 @@ usage: |-
               stack: "plat-ue2-sandbox"
               atmos-config-path: ./rootfs/usr/local/etc/atmos/
   ```
+  ### Migrating from `v3` to `v4`
+  
+  The notable changes in `v4` are:
+
+  - `v4` works only with `atmos >= 1.158.0`
+  - `v4` supports atnos `templates` and `functions`
 
   ### Migrating from `v2` to `v3`
   

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   atmos-version:
     description: The version of atmos to install
     required: false
-    default: ">= 1.99.0"
+    default: ">= 1.158.0"
   atmos-config-path:
     description: The path to the atmos.yaml file
     required: true
@@ -83,6 +83,7 @@ runs:
         # Here we do not process-templates because that requires terraform. Which we install after fetching the version
         # processing templates here can cause an issue where cached terraform versions conflict with the version we want to install
         process-templates: 'false'
+        process-functions: 'false'
         settings: |
           - component: ${{ inputs.component }}
             stack: ${{ inputs.stack }}


### PR DESCRIPTION
## Breaking Change!
* Requires `atmos >= 1.158.0`. Will fail on older version

## what
* Disable process functions for `cloudposse/github-action-atmos-get-setting`

## why
* `process-functions` requires terraform. Which we install after fetching the version
* `process-functions` can cause an issue where cached terraform versions conflict with the version we want to install
* `atmos < 1.158.0` not not support flag `--process-functions`



