### PR TITLE
Planfile Fix for apply action

### DIFF
--- a/.github/workflows/integration-atmos-pro-tests.yml
+++ b/.github/workflows/integration-atmos-pro-tests.yml
@@ -47,7 +47,7 @@ jobs:
           cat ${{ runner.temp }}/atmos.yaml
 
       - name: Plan Atmos Component
-        uses: cloudposse/github-action-atmos-terraform-plan@v4
+        uses: cloudposse/github-action-atmos-terraform-plan@v5
         with:
           component: "foobar-atmos-pro"
           stack: "plat-ue2-sandbox"
@@ -80,7 +80,7 @@ jobs:
     steps:
       - uses: nick-fields/assert-action@v2
         with:
-          expected: 'succeeded'
+          expected: "succeeded"
           actual: "${{ needs.test.outputs.result }}"
 
   teardown:
@@ -89,4 +89,4 @@ jobs:
     if: ${{ always() }}
     steps:
       - name: Tear down
-        run: echo "Do Tear down" 
+        run: echo "Do Tear down"

--- a/action.yml
+++ b/action.yml
@@ -410,9 +410,9 @@ runs:
           --output "${{ github.workspace }}/atmos-apply-summary.md" \
           --log-level $([[ "${{ inputs.debug }}" == "true" ]] && echo "DEBUG" || echo "INFO") \
           apply -- \
-            atmos terraform apply ${{ inputs.component }} \
+            atmos terraform deploy ${{ inputs.component }} \
             --stack ${{ inputs.stack }} \
-            -auto-approve \
+            --planfile ${{ steps.vars.outputs.plan_file }} \
             -input=false \
             -no-color \
         &> ${TERRAFORM_OUTPUT_FILE}


### PR DESCRIPTION
## what

The current apply workflow dies after fetching AWS credentials and never performs an apply action

## why

The Apply action has not updated the `atmos terraform deploy` functionality. The planpath is not supplied as part of the deployment process

## references
https://github.com/cloudposse/github-action-atmos-terraform-apply/pull/75
