### PR TITLE
Name of the renewed planfile is passed to plan command

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -365,6 +365,8 @@ runs:
             --stack ${{ inputs.stack }} \
             -input=false \
             -no-color \
+            --skip-planfile=true \
+            -out=${{ steps.vars.outputs.renewed_plan_file }} \
         &> ${TERRAFORM_PLAN_OUTPUT_FILE}
 
         PLAN_CHANGED=$?
@@ -376,8 +378,6 @@ runs:
           cat ./atmos-apply-summary.md >> $GITHUB_STEP_SUMMARY
           exit 1
         fi
-
-        cp ${{ steps.vars.outputs.plan_file }} ${{ steps.vars.outputs.renewed_plan_file }}
 
         TERRAFORM_PLAN_DIFF_OUTPUT_FILE="./terraform-${GITHUB_RUN_ID}-plan-diff-output.txt"
 

--- a/action.yml
+++ b/action.yml
@@ -238,10 +238,9 @@ runs:
         COMPONENT_NAME=$(echo "${{ inputs.component }}" | sed 's#/#_#g')
         COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
         COMPONENT_CACHE_KEY=$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")
-        PLANFILE_SLUG="$STACK_NAME-$(echo "${{ inputs.component }}" | sed 's#/#-#g')"
-        PLAN_FILENAME="$PLANFILE_SLUG.planfile"
+        PLAN_FILENAME="$COMPONENT_SLUG.planfile"
         PLAN_FILE="${COMPONENT_PATH}/${PLAN_FILENAME}"
-        RETRIEVED_PLAN_FILENAME="$PLANFILE_SLUG-${{ inputs.sha }}.planfile"
+        RETRIEVED_PLAN_FILENAME="$COMPONENT_SLUG-${{ inputs.sha }}.planfile"
         RETRIEVED_PLAN_FILE="${COMPONENT_PATH}/${RETRIEVED_PLAN_FILENAME}"
         RENEWED_PLAN_FILENAME="new.${RETRIEVED_PLAN_FILENAME}"
         RENEWED_PLAN_FILE="${COMPONENT_PATH}/${RENEWED_PLAN_FILENAME}"

--- a/action.yml
+++ b/action.yml
@@ -238,9 +238,10 @@ runs:
         COMPONENT_NAME=$(echo "${{ inputs.component }}" | sed 's#/#_#g')
         COMPONENT_SLUG="$STACK_NAME-$COMPONENT_NAME"
         COMPONENT_CACHE_KEY=$(basename "${{ fromJson(steps.atmos-settings.outputs.settings).component-path }}")
-        PLAN_FILENAME="$COMPONENT_SLUG.planfile"
+        PLANFILE_SLUG="$STACK_NAME-$(echo "${{ inputs.component }}" | sed 's#/#-#g')"
+        PLAN_FILENAME="$PLANFILE_SLUG.planfile"
         PLAN_FILE="${COMPONENT_PATH}/${PLAN_FILENAME}"
-        RETRIEVED_PLAN_FILENAME="$COMPONENT_SLUG-${{ inputs.sha }}.planfile"
+        RETRIEVED_PLAN_FILENAME="$PLANFILE_SLUG-${{ inputs.sha }}.planfile"
         RETRIEVED_PLAN_FILE="${COMPONENT_PATH}/${RETRIEVED_PLAN_FILENAME}"
         RENEWED_PLAN_FILENAME="new.${RETRIEVED_PLAN_FILENAME}"
         RENEWED_PLAN_FILE="${COMPONENT_PATH}/${RENEWED_PLAN_FILENAME}"


### PR DESCRIPTION
## what

The name of the planfile is passed to the Atmos Terraform plan to avoid errors in file naming.

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

## why

If the component name contains a slash (e.g., `eks/app`), atmos terraform plan creates a file named `plat-ue1-dev-eks-app.planfile` (at least for me with `atmos = 1.187.0`).

This action attempts to copy the file `plat-ue1-dev-eks_app.planfile`. This happens because of https://github.com/cloudposse/github-action-atmos-terraform-apply/blob/99b9b1eda20d0d77be6e4f18e1c67d0790104278/action.yml#L238

This is probably what causes my error after updating to v5.

> `cp: cannot stat '/home/runner/_work/***/***/deploy/atmos/components/terraform/eks/app/plat-ue1-dev-eks_app.planfile': No such file or directory`


To correct this error and avoid similar ones in the future, I would suggest specifying the expected name of the planfile directly.

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

## references

[--skip-planfile behaviour](https://atmos.tools/cli/commands/terraform/usage#additions-and-differences-from-native-terraform-and-opentofu)

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
